### PR TITLE
String search

### DIFF
--- a/controllers/searchList.js
+++ b/controllers/searchList.js
@@ -66,7 +66,11 @@ module.exports = {
       where: { UserId: userId, StatusId: { [Op.ne]: statusId }},
       include: [{
         model: db.Library,
-        where: { author: searchParamVal },
+        where:  
+          Sequelize.where(Sequelize.fn('lower', Sequelize.col('author')),
+          {
+            [Op.like]: Sequelize.fn('lower', '%' + searchParamVal + '%')
+          }),
         attributes: { exclude: ['id', 'createdAt', 'updatedAt'] }
       },
       {
@@ -79,13 +83,17 @@ module.exports = {
       }] 
     }).then(data => data),
 
-  title: (userId, statusId, searchParamVal) =>
+  title: (userId, statusId, searchParamVal) => 
     db.Reading_List.findAll({
       attributes: { exclude: ['createdAt', 'updatedAt'] },
       where: { UserId: userId, StatusId: { [Op.ne]: statusId }},
       include: [{
         model: db.Library,
-        where: { title: searchParamVal },
+        where:  
+          Sequelize.where(Sequelize.fn('lower', Sequelize.col('title')),
+          {
+            [Op.like]: Sequelize.fn('lower', '%' + searchParamVal + '%')
+          }),
         attributes: { exclude: ['id', 'createdAt', 'updatedAt'] }
       },
       {

--- a/controllers/searchList.js
+++ b/controllers/searchList.js
@@ -69,7 +69,8 @@ module.exports = {
         where:  
           Sequelize.where(Sequelize.fn('lower', Sequelize.col('author')),
           {
-            [Op.like]: Sequelize.fn('lower', '%' + searchParamVal + '%')
+            [Op.like]: Sequelize.fn('lower', 
+                        '%' + searchParamVal.replace(/ /g, '%') + '%')
           }),
         attributes: { exclude: ['id', 'createdAt', 'updatedAt'] }
       },
@@ -92,7 +93,8 @@ module.exports = {
         where:  
           Sequelize.where(Sequelize.fn('lower', Sequelize.col('title')),
           {
-            [Op.like]: Sequelize.fn('lower', '%' + searchParamVal + '%')
+            [Op.like]: Sequelize.fn('lower', 
+                        '%' + searchParamVal.replace(/ /g, '%') + '%')
           }),
         attributes: { exclude: ['id', 'createdAt', 'updatedAt'] }
       },

--- a/public/assets/js/bookmarks.js
+++ b/public/assets/js/bookmarks.js
@@ -27,14 +27,19 @@ $(document).ready(() => {
             var searchParamVal = $(".userText").val().trim();
         }
 
-        var url = "/api/list/" + userId + "/" + searchParam + "/" + searchParamVal;
-        console.log("GET request: " + url);
+        if (searchParam != "all" && searchParamVal.length === 0) {
+          alert("The search field cannot be blank!");  
+        }
+        else {
+            var url = "/api/list/" + userId + "/" + searchParam + "/" + searchParamVal;
+            console.log("GET request: " + url);
         
-        $.ajax(url, {
-            type: "GET"       
-        })
-        .then(data => {$("#list-results").html(data);})
-        .fail(error => console.error(error));
+            $.ajax(url, {
+                type: "GET"       
+            })
+            .then(data => {$("#list-results").html(data);})
+            .fail(error => console.error(error));
+        }
     });
 
     $("#selectSearchList").change(function() {

--- a/public/assets/js/bookmarks.js
+++ b/public/assets/js/bookmarks.js
@@ -122,7 +122,7 @@ $(document).ready(() => {
         .fail(error => console.error(error));
     });
 
-    $(document).on("click", ".delete-from-list", function (event) {e
+    $(document).on("click", ".delete-from-list", function (event) {
         var title = $(this).attr("data-title")
 
         var dataObj = {


### PR DESCRIPTION
Adds better matching for author and title searches. Uses like instead of sql =. Appends % to front and back of search string and replaces any blanks inside the search string with %.

Also added check for empty author and title search on the FE. Creates an alert if the search strings are blank.

Also - this includes that char fix from issue #106.